### PR TITLE
Protect public endpoints from spam

### DIFF
--- a/conf/conf.go
+++ b/conf/conf.go
@@ -8,6 +8,8 @@ type Env struct {
 	KeycloakClientID       string `split_words:"true" required:"true"`
 	KeycloakMembersGroupID string `split_words:"true" required:"true"`
 
+	MaxUnverifiedAccounts int `split_words:"true" default:"50"`
+
 	SelfURL          string `split_words:"true" required:"true"`
 	StripeKey        string `split_words:"true"`
 	StripeWebhookKey string `split_words:"true"`

--- a/main.go
+++ b/main.go
@@ -89,7 +89,7 @@ func newSignupViewHandler(kc *keycloak.Keycloak) http.HandlerFunc {
 }
 
 func newRegistrationFormHandler(kc *keycloak.Keycloak) http.HandlerFunc {
-	rateLimiter := newRateLimiter(10)
+	rateLimiter := newRateLimiter(10, 2)
 	return func(w http.ResponseWriter, r *http.Request) {
 		<-rateLimiter
 		viewData := map[string]any{"page": "signup", "success": true}
@@ -358,8 +358,8 @@ func renderSystemError(w http.ResponseWriter, msg string, args ...any) {
 	http.Error(w, "system error", 500)
 }
 
-func newRateLimiter(qpm int) <-chan struct{} {
-	ch := make(chan struct{}, 1)
+func newRateLimiter(qpm, burst int) <-chan struct{} {
+	ch := make(chan struct{}, burst)
 	ch <- struct{}{}
 	go func() {
 		ticker := time.NewTicker(time.Minute / time.Duration(qpm))

--- a/main.go
+++ b/main.go
@@ -94,6 +94,13 @@ func newRegistrationFormHandler(kc *keycloak.Keycloak) http.HandlerFunc {
 
 		err := kc.RegisterUser(r.Context(), r.FormValue("email"))
 
+		// Limit the number of accounts with unconfirmed email addresses to avoid spam/abuse
+		if errors.Is(err, keycloak.ErrLimitExceeded) {
+			err = nil
+			viewData["limitExceeded"] = true
+			viewData["success"] = false
+		}
+
 		// Currently we just render a descriptive error message when the user already exists.
 		// Consider having an option to start the password reset flow, or maybe do so by default.
 		if errors.Is(err, keycloak.ErrConflict) {

--- a/templates/signup.html
+++ b/templates/signup.html
@@ -22,6 +22,12 @@
                 </div>
                 {{- end }}
 
+                {{- if .limitExceeded }}
+                <div class="alert alert-warning" role="alert">
+                    Signups are currently closed due to spam. Please contact TheLab leadership in Discord.
+                </div>
+                {{- end }}
+
                 {{- if .conflict }}
                 <div class="alert alert-warning" role="alert">
                     This email address is already associated with an account.


### PR DESCRIPTION
There is currently only one unauthenticated endpoint that does meaningful work (calling keycloak) — the form post handler for signups.

This PR provides an upper bound on how many accounts with unverified email addresses can exist in Keycloak before blocking signups. This effectively prohibits spam at the cost of a relatively expensive Keycloak query. So I'm also adding a simple token bucket rate limiter to effectively limit how often the query can happen.
