### PR TITLE
Re-enable promo codes

### DIFF
--- a/main.go
+++ b/main.go
@@ -208,6 +208,7 @@ func newStripeCheckoutHandler(env *conf.Env, kc *keycloak.Keycloak, pc *stripeut
 		} else {
 			priceID := r.URL.Query().Get("price")
 			checkoutParams.Mode = stripe.String(string(stripe.CheckoutSessionModeSubscription))
+			checkoutParams.AllowPromotionCodes = stripe.Bool(true)
 			checkoutParams.Discounts = calculateDiscount(user, priceID, pc)
 			checkoutParams.LineItems = []*stripe.CheckoutSessionLineItemParams{{
 				Price:    stripe.String(priceID),


### PR DESCRIPTION
Promo code support was removed in #8 since it adds support for discounts. But we still have a need for individual promo codes in special cases.