### PR TITLE
Add support for prorated stripe subscriptions

### DIFF
--- a/templates/profile.html
+++ b/templates/profile.html
@@ -45,6 +45,16 @@
               <a href="/profile/cancel" role="button" class="btn btn-default">Cancel Membership</a>
             </div>
             {{- end }} {{- else }}
+            {{- if .user.LastPaypalTransactionTime }}
+            <div class="alert alert-info" role="alert">
+              We found a Paypal payment associated with your email address from {{
+              .user.LastPaypalTransactionTime.Format "01/02/2006" }}. Your account will be prorated accordingly when
+              signing up with Stripe.<br><br>
+              After signing up, you can cancel your existing Paypal subscription using a link in your latest Paypal
+              receipt
+              email.
+            </div>
+            {{- end }}
             <div class="btn-group" role="group" aria-label="...">
               {{- range .prices }}
               <a href="/profile/stripe?price={{ .ID }}" role="button" class="btn btn-default">{{ .ButtonText }}</a>


### PR DESCRIPTION
The app now consumes any paypal transaction metadata from keycloak to generate the correct billing cycle date. This will allow users to migrate to stripe without paying extra.