### PR TITLE
Keep paypal membership price when migrating

### DIFF
--- a/stripeutil/pricing.go
+++ b/stripeutil/pricing.go
@@ -14,8 +14,8 @@ import (
 )
 
 type Price struct {
-	ID, ButtonText        string
-	CouponsByDiscountType map[string]string
+	ID, ProductID, ButtonText string
+	CouponsByDiscountType     map[string]string
 }
 
 // PriceCache is used to store Stripe product prices in-memory to avoid fetching them when rendering pages.
@@ -89,6 +89,9 @@ func (p *PriceCache) listPrices() []*Price {
 			ID:                    price.ID,
 			ButtonText:            price.Metadata["ButtonText"],
 			CouponsByDiscountType: coupsMap[price.ID],
+		}
+		if price.Product != nil {
+			p.ProductID = price.Product.ID
 		}
 		if p.ButtonText == "" {
 			continue // skip prices that don't have button text

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -49,10 +49,12 @@
             <div class="alert alert-info" role="alert">
               We found a Paypal payment associated with your email address from {{
               .user.LastPaypalTransactionTime.Format "01/02/2006" }}. Your account will be prorated accordingly when
-              signing up with Stripe.<br><br>
+              migrating your membership to this system.<br><br>
               After signing up, you can cancel your existing Paypal subscription using a link in your latest Paypal
               receipt
-              email.
+              email.<br><br>
+              <a href="/profile/stripe?price=paypal" role="button" class="btn btn-default">
+                Migrate Existing Membership</a>
             </div>
             {{- end }}
             <div class="btn-group" role="group" aria-label="...">


### PR DESCRIPTION
The profile app will now continue existing users at their current price instead of applying the current monthly or yearly rate.

$50/mo is the threshold for dividing monthly and yearly membership prices. So any membership less than $50 will be considered monthly.